### PR TITLE
Fix layout handling in AddPageSidebar

### DIFF
--- a/src/components/AddPageSidebar.tsx
+++ b/src/components/AddPageSidebar.tsx
@@ -12,7 +12,7 @@ import { AddPageSidebarFooter } from "./addPageSidebar/AddPageSidebarFooter";
 interface AddPageSidebarProps {
   isOpen: boolean;
   onClose: () => void;
-  onCreatePage: (pageData: { title: string; slug: string }) => void;
+  onCreatePage: (pageData: { title: string; slug: string; layout: string }) => void;
   selectedLayout: string | null;
 }
 
@@ -39,7 +39,7 @@ export const AddPageSidebar = ({ isOpen, onClose, onCreatePage, selectedLayout }
       setActiveTab("general");
       setTitle("");
       setAddress("");
-      setLayout("2023-front-page");
+      setLayout(selectedLayout || "2023-front-page");
       setShowInMenu(true);
       setAccess("public");
       setIsLinkMode(false);
@@ -51,7 +51,7 @@ export const AddPageSidebar = ({ isOpen, onClose, onCreatePage, selectedLayout }
       setMetaDescription("");
       setVisibleToSearchEngines(true);
     }
-  }, [isOpen]);
+  }, [isOpen, selectedLayout]);
 
   // Auto-generate address from title
   useEffect(() => {
@@ -80,7 +80,7 @@ export const AddPageSidebar = ({ isOpen, onClose, onCreatePage, selectedLayout }
 
   const handleCreatePage = () => {
     if (title && address) {
-      onCreatePage({ title, slug: address });
+      onCreatePage({ title, slug: address, layout });
       onClose();
     }
   };

--- a/src/hooks/usePageActions.ts
+++ b/src/hooks/usePageActions.ts
@@ -50,9 +50,9 @@ export const usePageActions = (setPages: React.Dispatch<React.SetStateAction<Pag
     setSelectedLayout(null);
   };
 
-  const handleCreatePage = (pageData: { title: string; slug: string; }) => {
-    if (pageData.title && pageData.slug && selectedLayout) {
-      const layoutOption = layoutOptions.find(opt => opt.id === selectedLayout);
+  const handleCreatePage = (pageData: { title: string; slug: string; layout: string }) => {
+    if (pageData.title && pageData.slug) {
+      const layoutOption = layoutOptions.find(opt => opt.id === pageData.layout);
       const newPage = {
         id: Date.now().toString(),
         title: pageData.title,


### PR DESCRIPTION
## Summary
- keep selected layout when AddPageSidebar opens
- pass chosen layout back to parent
- update page creation logic to use the passed layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_686e4b5fe6c483329f03421176948bc9